### PR TITLE
allowed custom search filter on login

### DIFF
--- a/lib/ActiveDirectory.js
+++ b/lib/ActiveDirectory.js
@@ -132,9 +132,16 @@ class ActiveDirectory {
         return new Promise((resolve, reject) => {
             const client = ldap.createClient(this.ldapjsSettings);
             const base = typeof customBase === 'string' ? customBase : this.base;
-            const customSearch = {
+            // This part was modified to support custom search filters.
+            let customSearch = {};
+            if (!this.searchOptions.filter) customSearch = {
                 ...this.searchOptions,
                 filter: `(userPrincipalName=${username})`
+            } 
+            else {
+                customSearch = {
+                    ...this.searchOptions
+                }
             };
     
             // Return errors


### PR DESCRIPTION
Update is usefull when user can login to AD (windows) by userLogonName (which is userPrincipalName without sufffix)
In that case local AD will support your attempt to login, but you will not find the user with (userPrincipalName=${username}) filter. 
This will also make interresting situation when login attempt was successfull, but no user provided and no error provided. So it will be success=false, error = undefined - a very misleading mistake.
            
In my case AD had multiple possible suffixes, so that users could login to windows but not to my app, using node-ad-tool
To solve this i use ADconfig.searchOptions = { scope: 'sub', filter: `|(userPrincipalName=${userName})(samAccountName=${userName.split('@')[0]})` }; when instanciating new ActiveDirectory(ADconfig);